### PR TITLE
Make maximumContrast return Color, traverse list once only

### DIFF
--- a/src/Color/Accessibility.elm
+++ b/src/Color/Accessibility.elm
@@ -68,18 +68,27 @@ luminance cl =
 
 {-| Returns the color with the highest contrast to the base color.
 
-    bgColor = Color.darkBlue
-    textOptions = [ Color.white, Color.purple, Color.black ]
-
-    maximumContrast bgColor textOptions -- Just Color.white
+    maximumContrast Color.darkBlue Color.white [ Color.purple, Color.black ] -- Color.white
 
 -}
-maximumContrast : Color -> List Color -> Maybe Color
-maximumContrast base options =
-    let
-        compareContrast c1 c2 =
-            compare (contrastRatio base c2) (contrastRatio base c1)
-    in
-    options
-        |> List.sortWith compareContrast
-        |> List.head
+maximumContrast : Color -> Color -> List Color -> Color
+maximumContrast base first rest =
+    maximumContrastMemo (contrastRatio base) (contrastRatio base first) first rest
+
+
+maximumContrastMemo : (Color -> Float) -> Float -> Color -> List Color -> Color
+maximumContrastMemo ratioFn bestRatio bestColor colors =
+    case colors of
+        [] ->
+            bestColor
+
+        color :: rest ->
+            let
+                newRatio =
+                    ratioFn color
+            in
+            if bestRatio >= newRatio then
+                maximumContrastMemo ratioFn bestRatio bestColor rest
+
+            else
+                maximumContrastMemo ratioFn newRatio color rest

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -53,12 +53,12 @@ accessibility =
             \() ->
                 Expect.equal
                     (maximumContrast Color.yellow
-                        [ Color.white
-                        , Color.darkBlue
+                        Color.white
+                        [ Color.darkBlue
                         , Color.green
                         ]
                     )
-                    (Just Color.darkBlue)
+                    Color.darkBlue
         ]
 
 


### PR DESCRIPTION
Hi,

I figured it would make more sense to have `maximumContrast` return a `Color`, not a `Maybe Color`, by enforcing that at least one option is always given. I also used memoization to ensure that the contrast ratios are only calculated once for each `Color`, and that the list of options is only traversed once (I know that premature optimization is a "Bad Thing", but I actually do want to use this function against a very big list!).

P.S. I wasn't sure whether the type signature should be `Color -> Color -> List Color -> Color` or `Color -> (Color, List Color) -> Color`, but I went with the former because that's how [`Json.Decode.oneOrMore`](https://package.elm-lang.org/packages/elm/json/latest/Json-Decode#oneOrMore) does it.

P.P.S. I would have opened an issue to see if you were open to a PR for this, but I guess you don't have issues because this is a fork.